### PR TITLE
Build our docker images on top of gpuci/miniconda-cuda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,15 @@
 #
 
 ARG FROM_IMAGE=gpuci/miniconda-cuda
-ARG CUDA_VER=10.1 
+ARG CUDA_VERSION=10.1
 ARG LINUX_VERSION=ubuntu18.04
 ARG IMAGE_TYPE=devel
+FROM ${FROM_IMAGE}:${CUDA_VERSION}-${IMAGE_TYPE}-${LINUX_VERSION}
 
-FROM ${FROM_IMAGE}:${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VERSION}
-
-# Capture argument used for FROM
 ARG CC_VERSION=7
 ARG PYTHON_VERSION=3.6
-ARG CUDA_VER
+# Capture argument used for FROM
+ARG CUDA_VERSION
 
 # Update environment for gcc/g++ builds
 ENV CC=/usr/bin/gcc
@@ -49,7 +48,7 @@ RUN apt update && \
     libssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-    
+
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${CC_VERSION} 1000 --slave /usr/bin/g++ g++ /usr/bin/g++-${CC_VERSION}
 
 # Add a condarc for channels and override settings
@@ -71,7 +70,7 @@ RUN source activate base \
       -c defaults \
       -c gpuci \
       -c bioconda \
-      cudatoolkit=${CUDA_VER} \
+      cudatoolkit=${CUDA_VERSION} \
       git \
       gpuci-tools \
       htslib \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ FROM ${FROM_IMAGE}:${CUDA_VER}-${IMAGE_TYPE}-${LINUX_VERSION}
 # Capture argument used for FROM
 ARG CC_VERSION=7
 ARG PYTHON_VERSION=3.6
+ARG CUDA_VER
 
 # Update environment for gcc/g++ builds
 ENV CC=/usr/bin/gcc
@@ -70,6 +71,7 @@ RUN source activate base \
       -c defaults \
       -c gpuci \
       -c bioconda \
+      cudatoolkit=${CUDA_VER} \
       git \
       gpuci-tools \
       htslib \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2019-2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # NVIDIA CORPORATION and its licensors retain all intellectual property
 # and proprietary rights in and to this software, related documentation
@@ -8,16 +8,62 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-ARG CUDA_VERSION=9.2
-ARG LINUX_VERSION=ubuntu16.04
-ARG CC_VERSION=5
-ARG CXX_VERSION=5
+ARG FROM_IMAGE=gpuci/miniconda-cuda
+ARG CUDA_VERSION=10.1 
+ARG LINUX_VERSION=ubuntu18.04
+ARG CC_VERSION=7
+ARG IMAGE_TYPE=base
 ARG PYTHON_VERSION=3.6
 
-FROM gpuci/rapidsai-base:cuda${CUDA_VERSION}-${LINUX_VERSION}-gcc${CC_VERSION}-py${PYTHON_VERSION}
+FROM ${FROM_IMAGE}:${CUDA_VERSION}-${IMAGE_TYPE}-${LINUX_VERSION}
 
+# Capture argument used for FROM
+ARG CC_VERSION
+ARG CUDA_VERSION
+ARG PYTHON_VERSION
+
+# Update environment for gcc/g++ builds
+ENV CC=/usr/bin/gcc
+ENV CXX=/usr/bin/g++
+ENV CUDAHOSTCXX=/usr/bin/g++
+ENV CUDA_HOME=/usr/local/cuda
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
+# Enables "source activate conda"
+SHELL ["/bin/bash", "-c"]
+
+# Install gcc version
+RUN apt update && apt-get -y install g++-${CC_VERSION} gcc-${CC_VERSION} vim cmake make 
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${CC_VERSION} 1000 --slave /usr/bin/g++ g++ /usr/bin/g++-${CC_VERSION}
+
+# Installing cuda
+RUN apt update && apt-get -y install cuda-toolkit-$(echo "${CUDA_VERSION}" | sed -e "s/\./-/g" | cut -d- -f1-2)
+
+# Add a condarc for channels and override settings
+RUN echo -e "\
+ssl_verify: False \n\
+channels: \n\
+  - gpuci \n\
+  - conda-forge \n\
+  - nvidia \n\
+  - defaults \n" > /conda/.condarc \
+      && cat /conda/.condarc ;
+
+# Create rapids conda env and make default
+RUN source activate base \
+    && conda install -y gpuci-tools \
+    && gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+      -c nvidia \
+      -c conda-forge \
+      -c defaults \
+      -c gpuci \
+      git \
+      gpuci-tools \
+      python=${PYTHON_VERSION} \
+      "setuptools<50" \
+    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc ;
+
+# Install the packages needed to build with.
 # Install htslib dependencies
-RUN apt-get update
 RUN apt-get install -y tabix \
         zlib1g-dev \
         libbz2-dev \
@@ -28,3 +74,14 @@ RUN apt-get install -y tabix \
 
 # Install htslib
 RUN wget https://github.com/samtools/htslib/releases/download/1.9/htslib-1.9.tar.bz2 && tar xvf htslib-1.9.tar.bz2 && cd htslib-1.9 && ./configure && make -j16 install
+
+# ADD source dest
+# Create symlink for old scripts expecting `gdf` conda env
+RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf
+
+# Clean up pkgs to reduce image size
+RUN conda clean -afy \
+    && chmod -R ugo+w /opt/conda
+
+ENTRYPOINT [ "/usr/bin/tini", "--" ]
+CMD [ "/bin/bash" ]

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -8,22 +8,96 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-ARG CUDA_VERSION=10.0
-ARG LINUX_VERSION=centos7
-ARG CC_VERSION=7
-ARG CXX_VERSION=7
-ARG PYTHON_VERSION=3.6
+ARG FROM_IMAGE=gpuci/miniconda-cuda
+ARG CUDA_VER=10.0
+ARG IMAGE_TYPE=devel
+FROM ${FROM_IMAGE}:${CUDA_VER}-${IMAGE_TYPE}-centos7
 
-FROM gpuci/rapidsai-base:cuda${CUDA_VERSION}-${LINUX_VERSION}-gcc${CC_VERSION}-py${PYTHON_VERSION}
+# Capture arguments used for FROM
+ARG CUDA_VER
+
+ARG CC_VERSION=7
+ARG PYTHON_VERSION=3.6
+ARG CENTOS7_GCC7_URL=https://gpuci.s3.us-east-2.amazonaws.com/builds/gcc7.tgz
+
+# Update environment for gcc/g++ builds
+ENV GCC7_DIR=/usr/local/gcc7
+ENV CC=${GCC7_DIR}/bin/gcc
+ENV CXX=${GCC7_DIR}/bin/g++
+ENV CUDAHOSTCXX=${GCC7_DIR}/bin/g++
+ENV CUDA_HOME=/usr/local/cuda
+ENV LD_LIBRARY_PATH=${GCC7_DIR}/lib64:$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
+ENV PATH=${GCC7_DIR}/bin:$PATH
+
+# Enables "source activate conda"
+SHELL ["/bin/bash", "-c"]
 
 # Install custom packages
 RUN yum -y install rpm-build \
+        screen \
+        vim \
         zlib-devel \
         bzip2-devel \
         xz-devel \
         libcurl-devel \
         wget \
-        libssl-dev      # VariantWorks `cyvcf2` dependency
+        # VariantWorks `cyvcf2` dependency
+        libssl-dev \
+        # cmake3 dependency
+        openssl-devel
+
+# Add a condarc for channels and override settings
+RUN echo -e "\
+ssl_verify: False \n\
+channels: \n\
+  - gpuci \n\
+  - conda-forge \n\
+  - nvidia \n\
+  - defaults \n" > /conda/.condarc \
+      && cat /conda/.condarc ;
+
+# Create `rapids` conda env and make default
+RUN source activate base \
+    && conda install -y gpuci-tools \
+    && gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+      -c nvidia \
+      -c conda-forge \
+      -c defaults \
+      -c gpuci \
+      git \
+      gpuci-tools \
+      python=${PYTHON_VER} \
+      "setuptools<50" \
+    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
+
+# Install gcc7 from prebuilt tarball
+RUN gpuci_retry wget --quiet ${CENTOS7_GCC7_URL} -O /gcc7.tgz \
+    && tar xzvf /gcc7.tgz \
+    && rm -f /gcc7.tgz
+
+# Install cmake3
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.18.3/cmake-3.18.3.tar.gz \
+    && tar zxvf cmake-3.* \
+    && rm -rf cmake-3*.tar.gz \
+    && cd cmake-3.* \
+    && ./bootstrap --prefix=/usr/local \
+    && make -j16 \
+    && make install
 
 # Install htslib
-RUN wget https://github.com/samtools/htslib/releases/download/1.9/htslib-1.9.tar.bz2 && tar xvf htslib-1.9.tar.bz2 && cd htslib-1.9 && ./configure && make -j16 install
+RUN wget https://github.com/samtools/htslib/releases/download/1.9/htslib-1.9.tar.bz2 \
+    && tar xvf htslib-1.9.tar.bz2 \
+    && rm -rf htslib-1.9.tar.bz2 \
+    && cd htslib-1.9 \
+    && ./configure \
+    && make -j16 install
+
+# Create symlink for old scripts expecting `gdf` conda env
+RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf
+
+# Clean up pkgs to reduce image size and chmod for all users
+RUN conda clean -afy \
+    && chmod -R ugo+w /opt/conda
+
+ENTRYPOINT [ "/usr/bin/tini", "--" ]
+CMD [ "/bin/bash" ]

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -65,6 +65,7 @@ RUN source activate base \
       -c defaults \
       -c gpuci \
       -c bioconda \
+      cudatoolkit=${CUDA_VER} \
       git \
       gpuci-tools \
       htslib \

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -56,19 +56,21 @@ channels: \n\
   - defaults \n" > /conda/.condarc \
       && cat /conda/.condarc ;
 
-# Create `rapids` conda env and make default
+# Create `parabricks` conda env and make default
 RUN source activate base \
     && conda install -y gpuci-tools \
-    && gpuci_conda_retry create --no-default-packages --override-channels -n rapids \
+    && gpuci_conda_retry create --no-default-packages --override-channels -n parabricks \
       -c nvidia \
       -c conda-forge \
       -c defaults \
       -c gpuci \
+      -c bioconda \
       git \
       gpuci-tools \
+      htslib \
       python=${PYTHON_VER} \
       "setuptools<50" \
-    && sed -i 's/conda activate base/conda activate rapids/g' ~/.bashrc
+    && sed -i 's/conda activate base/conda activate parabricks/g' ~/.bashrc
 
 # Install gcc7 from prebuilt tarball
 RUN gpuci_retry wget --quiet ${CENTOS7_GCC7_URL} -O /gcc7.tgz \
@@ -84,16 +86,8 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.18.3/cmake-3.18.3
     && make -j16 \
     && make install
 
-# Install htslib
-RUN wget https://github.com/samtools/htslib/releases/download/1.9/htslib-1.9.tar.bz2 \
-    && tar xvf htslib-1.9.tar.bz2 \
-    && rm -rf htslib-1.9.tar.bz2 \
-    && cd htslib-1.9 \
-    && ./configure \
-    && make -j16 install
-
 # Create symlink for old scripts expecting `gdf` conda env
-RUN ln -s /opt/conda/envs/rapids /opt/conda/envs/gdf
+RUN ln -s /opt/conda/envs/parabricks /opt/conda/envs/gdf
 
 # Clean up pkgs to reduce image size and chmod for all users
 RUN conda clean -afy \

--- a/Dockerfile.drivers
+++ b/Dockerfile.drivers
@@ -8,23 +8,24 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
+ARG FROM_IMAGE=gpuci/clara-genomics-base
 ARG CUDA_VERSION=9.2
 ARG LINUX_VERSION=ubuntu16.04
 ARG CC_VERSION=5
 ARG CXX_VERSION=5
 ARG PYTHON_VERSION=3.6
 
-FROM gpuci/rapidsai-base-driver:cuda${CUDA_VERSION}-${LINUX_VERSION}-gcc${CC_VERSION}-py${PYTHON_VERSION}
+FROM ${FROM_IMAGE}:cuda${CUDA_VERSION}-${LINUX_VERSION}-gcc${CC_VERSION}-py${PYTHON_VERSION}
 
-# Install htslib dependencies
-RUN apt-get update
-RUN apt-get install -y tabix \
-        zlib1g-dev \
-        libbz2-dev \
-        liblzma-dev \
-        libcurl4-gnutls-dev \
-        wget \
-        libssl-dev      # VariantWorks `cyvcf2` dependency
+# Installs cuda-drivers and cuda libraries for conda builds on CPU-only machines
 
-# Install htslib
-RUN wget https://github.com/samtools/htslib/releases/download/1.9/htslib-1.9.tar.bz2 && tar xvf htslib-1.9.tar.bz2 && cd htslib-1.9 && ./configure && make -j16 install
+# Required arguments
+ARG DRIVER_VER="440"
+
+# Update and add pkgs
+RUN apt-get update -q \
+    && apt-get -qq install apt-utils -y --no-install-recommends \
+      nvidia-headless-${DRIVER_VER} \
+      libnvidia-compute-${DRIVER_VER} \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.drivers
+++ b/Dockerfile.drivers
@@ -8,23 +8,82 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-ARG FROM_IMAGE=gpuci/clara-genomics-base
-ARG CUDA_VER=9.2
+ARG FROM_IMAGE=gpuci/miniconda-cuda-driver
+ARG CUDA_VERSION=10.1
 ARG LINUX_VERSION=ubuntu16.04
+ARG IMAGE_TYPE=devel
+FROM ${FROM_IMAGE}:${CUDA_VERSION}-${IMAGE_TYPE}-${LINUX_VERSION}
+
 ARG CC_VERSION=5
-ARG PYTHON_VERSION=3.6
+ARG PYTHON_VERSION=3.7
+# Capture argument used for FROM
+ARG CUDA_VERSION
 
-FROM ${FROM_IMAGE}:cuda${CUDA_VER}-${LINUX_VERSION}-gcc${CC_VERSION}-py${PYTHON_VERSION}
+# Update environment for gcc/g++ builds
+ENV CC=/usr/bin/gcc
+ENV CXX=/usr/bin/g++
+ENV CUDAHOSTCXX=/usr/bin/g++
+ENV CUDA_HOME=/usr/local/cuda
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
 
-# Installs cuda-drivers and cuda libraries for conda builds on CPU-only machines
+# Enables "source activate conda"
+SHELL ["/bin/bash", "-c"]
 
-# Required arguments
-ARG DRIVER_VER="440"
-
-# Update and add pkgs
-RUN apt-get update -q \
-    && apt-get -qq install apt-utils -y --no-install-recommends \
-      nvidia-headless-${DRIVER_VER} \
-      libnvidia-compute-${DRIVER_VER} \
+RUN apt update && \
+    apt-get -y install  vim \
+    # Install gcc version
+    g++-${CC_VERSION} \
+    gcc-${CC_VERSION} \
+    cmake \
+    make \
+    # Install the packages needed to build with.
+    # Install htslib dependencies
+    wget \
+    tabix \
+    zlib1g-dev \
+    libbz2-dev \
+    liblzma-dev \
+    libcurl4-gnutls-dev \
+    # VariantWorks `cyvcf2` dependency
+    libssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${CC_VERSION} 1000 --slave /usr/bin/g++ g++ /usr/bin/g++-${CC_VERSION}
+
+# Add a condarc for channels and override settings
+RUN echo -e "\
+ssl_verify: False \n\
+channels: \n\
+  - gpuci \n\
+  - conda-forge \n\
+  - nvidia \n\
+  - defaults \n" > /conda/.condarc \
+      && cat /conda/.condarc ;
+
+# Create parabricks conda env and make default
+RUN source activate base \
+    && conda install -y gpuci-tools \
+    && gpuci_conda_retry create --no-default-packages --override-channels -n parabricks \
+      -c nvidia \
+      -c conda-forge \
+      -c defaults \
+      -c gpuci \
+      -c bioconda \
+      cudatoolkit=${CUDA_VERSION} \
+      git \
+      gpuci-tools \
+      htslib \
+      python=${PYTHON_VERSION} \
+      "setuptools<50" \
+    && sed -i 's/conda activate base/conda activate parabricks/g' ~/.bashrc ;
+
+# ADD source dest
+# Create symlink for old scripts expecting `gdf` conda env
+RUN ln -s /opt/conda/envs/parabricks /opt/conda/envs/gdf
+
+# Clean up pkgs to reduce image size
+RUN conda clean -afy && chmod -R ugo+w /opt/conda
+
+ENTRYPOINT [ "/usr/bin/tini", "--" ]
+CMD [ "/bin/bash" ]

--- a/Dockerfile.drivers
+++ b/Dockerfile.drivers
@@ -9,13 +9,12 @@
 #
 
 ARG FROM_IMAGE=gpuci/clara-genomics-base
-ARG CUDA_VERSION=9.2
+ARG CUDA_VER=9.2
 ARG LINUX_VERSION=ubuntu16.04
 ARG CC_VERSION=5
-ARG CXX_VERSION=5
 ARG PYTHON_VERSION=3.6
 
-FROM ${FROM_IMAGE}:cuda${CUDA_VERSION}-${LINUX_VERSION}-gcc${CC_VERSION}-py${PYTHON_VERSION}
+FROM ${FROM_IMAGE}:cuda${CUDA_VER}-${LINUX_VERSION}-gcc${CC_VERSION}-py${PYTHON_VERSION}
 
 # Installs cuda-drivers and cuda libraries for conda builds on CPU-only machines
 


### PR DESCRIPTION
This images are based on `gpuci/miniconda-cuda`  repository instead of the deprecated `gpuci/rapidsai-base` & `gpuci/rapidsai-base-driver` repositories.

Fixes https://github.com/clara-parabricks/GenomeWorks/issues/460